### PR TITLE
feat/mdx-subfolders

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,102 +1,103 @@
 module.exports = {
-    siteMetadata: {
-        title: '<Whitelabel>',
-        titleTemplate: '%s · <Whitelabel>',
-        description: 'A portfolio work by Edinburgh based, product designer Andrew Cetnarskyj.',
-        siteUrl: 'https://andrewcetnarskyj.co.uk', // No trailing slash allowed!
-        image: '/images/banner.jpg', // Path to your image you placed in the 'static' folder
-        twitterUsername: '@justandydesign1',
-        menuLinks:[
-            {
-                label:'home',
-                url:'/'
-            },
-            {
-                label:'About',
-                url:'/about'
-            },
-            {
-                label:'Docs',
-                url:'/docs/example'
-            },
-            {
-                label:'Articles',
-                url:'/articles/guide'
-            }
-        ],
-        social: [
-            {
-                name: 'twitter',
-                url: 'https://twitter.com/justandydesign1',
-            },
-            {
-                name: 'github',
-                url: 'https://github.com/just-andy',
-            },
-            {
-                name: 'instagram',
-                url: 'https://github.com/just-andy',
-            },
-            {
-                name: 'linkedin',
-                url: 'https://www.linkedin.com/in/andrewcetnarskyj/',
-            },
-        ],
-    },
-    plugins: [
-        `gatsby-plugin-image`,
-        `gatsby-plugin-react-helmet`,
-        `gatsby-plugin-postcss`,
-        //`gatsby-plugin-sitemap`,
-        `gatsby-plugin-sharp`,
-        `gatsby-transformer-sharp`,
-        `gatsby-remark-images`,
-        {
-          resolve: `gatsby-plugin-mdx`,
-          options: {
-            gatsbyRemarkPlugins: [
-              {
-                resolve: "gatsby-remark-embed-video",
-                options: {
-                  containerClass: "embedVideo-container", //Optional: Custom CSS class for iframe container, for multiple classes separate them by space
-                },
-              },
-              {
-                resolve: `gatsby-remark-images`,
-                options: {
-                  maxWidth: 1024,
-                },
-              },
-              `gatsby-remark-prismjs`
-            ],
-          },
-        },
-        {
-            resolve: `gatsby-plugin-manifest`,
-            options: {
-                icon: `src/images/favicon.png`,
-            },
-        },
-        {
-            resolve: `gatsby-source-filesystem`,
-            options: {
-                name: `banners`,
-                path: `${__dirname}/src/images/`,
-            },
-        },
-        {
-            resolve: `gatsby-source-filesystem`,
-            options: {
-                name: `docs`,
-                path: `${__dirname}/src/content/docs/`,
-            },
-        },
-        {
-            resolve: `gatsby-source-filesystem`,
-            options: {
-                name: `articles`,
-                path: `${__dirname}/src/content/articles/`,
-            },
-        },
+  siteMetadata: {
+    title: '<Whitelabel>',
+    titleTemplate: '%s · <Whitelabel>',
+    description:
+      'A portfolio work by Edinburgh based, product designer Andrew Cetnarskyj.',
+    siteUrl: 'https://andrewcetnarskyj.co.uk', // No trailing slash allowed!
+    image: '/images/banner.jpg', // Path to your image you placed in the 'static' folder
+    twitterUsername: '@justandydesign1',
+    menuLinks: [
+      {
+        label: 'home',
+        url: '/'
+      },
+      {
+        label: 'About',
+        url: '/about'
+      },
+      {
+        label: 'Docs',
+        url: '/docs'
+      },
+      {
+        label: 'Articles',
+        url: '/articles'
+      }
     ],
+    social: [
+      {
+        name: 'twitter',
+        url: 'https://twitter.com/justandydesign1'
+      },
+      {
+        name: 'github',
+        url: 'https://github.com/just-andy'
+      },
+      {
+        name: 'instagram',
+        url: 'https://github.com/just-andy'
+      },
+      {
+        name: 'linkedin',
+        url: 'https://www.linkedin.com/in/andrewcetnarskyj/'
+      }
+    ]
+  },
+  plugins: [
+    `gatsby-plugin-image`,
+    `gatsby-plugin-react-helmet`,
+    `gatsby-plugin-postcss`,
+    //`gatsby-plugin-sitemap`,
+    `gatsby-plugin-sharp`,
+    `gatsby-transformer-sharp`,
+    `gatsby-remark-images`,
+    {
+      resolve: `gatsby-plugin-mdx`,
+      options: {
+        gatsbyRemarkPlugins: [
+          {
+            resolve: 'gatsby-remark-embed-video',
+            options: {
+              containerClass: 'embedVideo-container' //Optional: Custom CSS class for iframe container, for multiple classes separate them by space
+            }
+          },
+          {
+            resolve: `gatsby-remark-images`,
+            options: {
+              maxWidth: 1024
+            }
+          },
+          `gatsby-remark-prismjs`
+        ]
+      }
+    },
+    {
+      resolve: `gatsby-plugin-manifest`,
+      options: {
+        icon: `src/images/favicon.png`
+      }
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `banners`,
+        path: `${__dirname}/src/images/`
+      }
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `docs`,
+        path: `${__dirname}/src/content/docs/`
+      }
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `articles`,
+        path: `${__dirname}/src/content/articles/`
+      }
+    }
+  ]
 };

--- a/src/pages/articles.tsx
+++ b/src/pages/articles.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link, useStaticQuery, graphql } from 'gatsby';
+
+import Seo from '../components/Seo';
+
+const Articles = () => {
+  const {
+    allMdx: { nodes }
+  } = useStaticQuery(graphql`
+    query {
+      allMdx(filter: { fileAbsolutePath: { regex: "//articles//" } }) {
+        nodes {
+          frontmatter {
+            title
+          }
+          slug
+        }
+      }
+    }
+  `);
+
+  return (
+    <section className="container">
+      <Seo title="Articles" description="This is description" />
+      <h1>Articles List</h1>
+      <p>Here are all the article pages</p>
+      <ul>
+        {nodes.map((node, index) => {
+          const {
+            slug,
+            frontmatter: { title }
+          } = node;
+          return (
+            <li key={index}>
+              <Link to={`/articles/${slug}`}>{title}</Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default Articles;

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link, useStaticQuery, graphql } from 'gatsby';
+
+import Seo from '../components/Seo';
+
+const Docs = () => {
+  const {
+    allMdx: { nodes }
+  } = useStaticQuery(graphql`
+    query {
+      allMdx(filter: { fileAbsolutePath: { regex: "//docs//" } }) {
+        nodes {
+          frontmatter {
+            title
+          }
+          slug
+        }
+      }
+    }
+  `);
+
+  return (
+    <section className="container">
+      <Seo title="Docs" description="This is description" />
+      <h1>Docs List</h1>
+      <p>Here are all the docs pages</p>
+      <ul>
+        {nodes.map((node, index) => {
+          const {
+            slug,
+            frontmatter: { title }
+          } = node;
+          return (
+            <li key={index}>
+              <Link to={`/docs/${slug}`}>{title}</Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default Docs;


### PR DESCRIPTION
- add docs list page
- add articles list page
- amend nav paths in `gatsby-config.js`

Hi Andy, not sure if this answers your question but this looks like it'll work. The path to each "docs" pages if formed from the sub directory name and the mdx file name, and each link in the list displays the frontmatter.title and uses the slug as a path